### PR TITLE
Remove Json.NET and update NuGet package references

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -125,7 +125,7 @@ listed below.
 -------------------------------------------------------------------------------
 
 This product includes software developed by Xceed Software Inc. Portions
-relating to the Extended WPF Toolkit™ (version 2.9.0) are subject to the terms
+relating to the Extended WPF Toolkit™ (version 4.5.0) are subject to the terms
 of the Microsoft Public License.
 
 > Copyright © 2010–2016 Xceed Software Inc.
@@ -137,35 +137,9 @@ of the Microsoft Public License.
 
 This product includes software developed by Giacomo Stelluti Scala &
 Contributors. Portions relating to the Command Line Parser Library (version
-2.0.275-beta) are subject to the terms of the MIT license as listed below.
+2.9.1) are subject to the terms of the MIT license as listed below.
 
 > Copyright © 2005–2015 Giacomo Stelluti Scala & Contributors.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy 
-> of this software and associated documentation files (the "Software"), to deal 
-> in the Software without restriction, including without limitation the rights 
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-> of the Software, and to permit persons to whom the Software is furnished to do 
-> so, subject to the following conditions: 
-> 
-> The above copyright notice and this permission notice shall be included in all 
-> copies or substantial portions of the Software. 
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-> THE SOFTWARE.
-
--------------------------------------------------------------------------------
-
-This product includes software developed by James Newton-King. Portions
-relating to the Json.NET Library (version 9.0.1) are subject to the terms of
-the MIT license as listed below.
-
-> Copyright © 2007 James Newton-King.
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy 
 > of this software and associated documentation files (the "Software"), to deal 

--- a/launcher/launcher.csproj
+++ b/launcher/launcher.csproj
@@ -288,16 +288,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Extended.Wpf.Toolkit">
-      <Version>4.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="StringInterpolationBridgeStrong">
       <Version>0.9.1</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>6.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
We're not using Json.NET for anything any more, and a few of our other NuGet references were out of date.