### PR TITLE
Fix CI builds for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # git complains when cloning the submodules without this
       - name: Checkout branding
-        if: github.repository == 'Windower/Fenestra'
+        if:
+          github.repository == 'Windower/Fenestra' &&
+          github.event_name == 'push'
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.BRANDING_PAT }}
@@ -41,7 +43,9 @@ jobs:
           ref: ${{ github.ref_name == 'stable' && '5.0/release' || '5.0/test' }}
           path: branding
       - name: Apply branding
-        if: github.repository == 'Windower/Fenestra'
+        if:
+          github.repository == 'Windower/Fenestra' &&
+          github.event_name == 'push'
         run: |
           Remove-Item 'branding/.git' -Recurse -Force
           Copy-Item 'branding/*' 'main' -Recurse -Force


### PR DESCRIPTION
When executing GitHub actions for a pull request event, we don't have access to repository secrets, and therefore, can't clone the branding files from the private repo.

This just disables branding entirely for PR builds.